### PR TITLE
Change path appends in filter_sims_sotodlib.py to relative path.

### DIFF
--- a/pipeline/filtering/filter_sims_sotodlib.py
+++ b/pipeline/filtering/filter_sims_sotodlib.py
@@ -15,8 +15,8 @@ from sotodlib.core.metadata import loader
 from pixell import enmap
 from mpi4py import MPI
 
-sys.path.append("/global/homes/k/kwolz/bbdev/bb-awg-scripts/pipeline/bundling")
-sys.path.append("/global/homes/k/kwolz/bbdev/bb-awg-scripts/pipeline/misc")
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..','bundling')))
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..','misc')))
 from coordinator import BundleCoordinator  # noqa
 from mpi_utils import distribute_tasks  # noqa
 


### PR DESCRIPTION
Change path appends to path relative to file location, so other users don't need to be able to read Kevin's home directory. 