### PR TITLE
Filtering with yaml config

### DIFF
--- a/pipeline/bundling/coordinator.py
+++ b/pipeline/bundling/coordinator.py
@@ -134,7 +134,7 @@ class BundleCoordinator:
                 null_prop_name = "_".join(npv.split("_")[1:])
                 if null_prop_name not in db_props:
                     raise ValueError(f"null_prop_name {null_prop_name} "
-                                      "not in db_props")
+                                     "not in db_props")
                 add_query += f" {keyword} {null_prop_name} = '{npv}'"
         query = cursor.execute(f"SELECT {query_fmt} FROM bundles{add_query}")
         results = np.asarray(query.fetchall())
@@ -183,14 +183,17 @@ class BundleCoordinator:
         """
         """
         filter = (self.bundle_ids == int(bundle_id))
-        ctimes = self.ctime[filter]
+        if hasattr(self, "timestamp"):
+            timestamps = self.timestamp[filter]
+        else:  # old bundle_db before 20250304
+            timestamps = self.ctime[filter]
         if null_prop_val not in [None, "science"]:
             name_prop = "_".join(null_prop_val.split("_")[1:])
             prop_val = getattr(self, name_prop)[filter]
             filter = prop_val == null_prop_val
-            ctimes = ctimes[filter]
+            timestamps = timestamps[filter]
 
-        return ctimes
+        return timestamps
 
     def save_db(self, db_path, overwrite=True):
         """

--- a/pipeline/bundling/filtering_utils.py
+++ b/pipeline/bundling/filtering_utils.py
@@ -1,0 +1,282 @@
+import os
+import yaml
+import numpy as np
+import healpy as hp
+from typing import Optional
+from dataclasses import dataclass
+import matplotlib.pyplot as plt
+
+from pixell import enmap, enplot
+from sotodlib.coords.demod import make_map
+from sotodlib.coords import P
+
+
+def yaml_loader(config):
+    """
+    Custom yaml loader to load the configuration file.
+    """
+    def path_constructor(loader, node):
+        return "/".join(loader.construct_sequence(node))
+    yaml.SafeLoader.add_constructor("!path", path_constructor)
+    with open(config, "r") as f:
+        return yaml.load(f, Loader=yaml.SafeLoader)
+
+
+def get_atomics_maps_list(sim_id, pure_type, atomic_metadata, freq_channel,
+                          atomic_sim_dir, split_label, sim_string_format,
+                          mfmt=".fits", pix_type="car", remove_atomics=False,
+                          logger=None):
+    """
+    Returns a list of filtered atomic maps that correpsond to a given
+    simulation ID, given a list of atomic metadata.
+
+    Parameters:
+        sim_id: int
+            Simulation ID.
+        atomic_metadata: list
+            List of tuples if strings (obs_id, wafer, freq_channel).
+        split_label: str
+            Map string label corresponding to the split, e.g. 'det_left'
+        sim_string_format: str
+            String format for the filtered atomic maps.
+            Must contain {sim_id}, {pure_type}.
+        mfmt: str
+            Atomic file name ending.
+        pix_type: str
+            Pixelization type; either 'car' or 'hp'.
+        remove_atomics: bool
+            Whether to remove atomic map files after loading into list.
+        logger: sotodlib.preprocess.preprocess_util.logger
+            Logger instance to print output.
+    Returns:
+        wmap_list: list
+            List of weighted maps (numpy.ndmap or numpy.ndarray)
+        w_list: list
+            List of map weights (numpy.ndmap or numpy.ndarray)
+    """
+    wmap_list, w_list = ([], [])
+
+    for id, (obs_id, wafer) in enumerate(atomic_metadata):
+        atomic_fname = sim_string_format.format(sim_id=sim_id,
+                                                pure_type=pure_type)
+        atomic_fname = atomic_fname.replace(
+            mfmt,
+            f"_{obs_id}_{wafer}_{freq_channel}_{split_label}{mfmt}"
+        )
+        fname_wmap, fname_w = (
+            f"{atomic_sim_dir}/{atomic_fname.replace(mfmt, f'_{s}{mfmt}')}"
+            for s in ("wmap", "weights")
+        )
+
+        # Observations can vanish if the FP thinning and the detector cuts
+        # conspire such that no detectors are left. Since this is a rare
+        # case, it is acceptable to just ignore those when coadding.
+        if not (os.path.isfile(fname_wmap) and os.path.isfile(fname_w)):
+            continue
+
+        if pix_type == "car":
+            wmap = enmap.read_map(fname_wmap)
+            w = enmap.read_map(fname_w)
+        elif pix_type == "hp":
+            wmap = hp.read_map(fname_wmap, field=range(3), nest=True)
+            w = hp.read_map(fname_w, field=range(3), nest=True)
+
+        wmap_list.append(wmap)
+        w_list.append(w)
+
+        if remove_atomics:
+            os.remove(fname_wmap)
+            os.remove(fname_w)
+
+    logger.info(f"{id+1} atomics expected, {len(wmap_list)} atomics at disk.")
+
+    return wmap_list, w_list
+
+
+def save_and_plot_map(map, out_fname, out_dir, plot_dir, pix_type="car",
+                      do_plot=True):
+    """
+    Saves and optionally plots TQU map.
+    """
+    if pix_type == "car":
+        enmap.write_map(f"{out_dir}/{out_fname}", map)
+
+    elif pix_type == "hp":
+        hp.write_map(
+            f"{out_dir}/{out_fname}", map, dtype=np.float64, overwrite=True,
+            nest=True
+        )
+    if not do_plot:
+        return
+
+    for i, f in zip([0, 1, 2], ["I", "Q", "U"]):
+        if pix_type == "car":
+            if isinstance(map, tuple):
+                map = map[0]  # For enmap.ndmaps
+            plot = enplot.plot(
+                map[i], color="planck", ticks=10, range=1.7, colorbar=True
+            )
+            enplot.write(
+                f"{plot_dir}/{out_fname.replace('.fits', '')}_{f}", plot
+            )
+
+        elif pix_type == "hp":
+            plt.figure()
+            hp.mollview(
+                map[i], cmap="RdYlBu_r", min=-1.7, max=1.7,
+                cbar=True, nest=True, unit=r"$\mu$K"
+            )
+            plt.savefig(
+                f"{plot_dir}/{out_fname.replace('.fits', '')}_{f}.png"
+            )
+            plt.close()
+
+
+def get_query_atomics(freq_channel, ctimes, split_label="science",
+                      query_restrict="median_weight_qu < 2e10"):
+    """
+    """
+    query = f"""
+            SELECT obs_id, wafer
+            FROM atomic
+            WHERE freq_channel == '{freq_channel}'
+            AND ctime IN {tuple(ctimes)}
+            AND split_label == '{split_label}'
+            """
+    if split_label != "science":
+        # The "valid" argument is not meant to be used with the "science" split
+        query += " AND valid == 1"
+    elif query_restrict:
+        # If we want "science", then we have to use "query_restrict". On the
+        # other hand, if we don't use the "science" split, the observations
+        # will have been restricted prior to that, so we ignore it there.
+        query += f" AND {query_restrict}"
+    return query
+
+
+def get_fullsky_geometry(res_arcmin=5., variant="fejer1"):
+    """
+    Generates a fullsky CAR template at resolution res-arcmin.
+    """
+    res = res_arcmin * np.pi/180/60
+    return enmap.fullsky_geometry(res=res, proj='car', variant=variant)
+
+
+def make_map_wrapper(obs, split_labels, pix_type="hp", shape=None, wcs=None,
+                     nside=None, site=None, logger=None):
+    """
+    """
+    obs.wrap("weather", np.full(1, "toco"))
+    obs.wrap("site", np.full(1, site))
+    if pix_type == "car":
+        nside = None
+        assert wcs is not None
+    elif pix_type == "hp":
+        wcs = None
+        assert nside is not None
+
+    inv_var = 1 / obs.preprocess.noiseQ_nofit.white_noise ** 2
+
+    wmap_dict = {}
+    weights_dict = {}
+
+    for split_label in split_labels:
+        cuts = obs.flags.glitch_flags + ~obs.preprocess.split_flags.cuts[split_label]  # noqa
+
+        Proj = P.for_tod(obs, wcs_kernel=wcs, comps='TQU', cuts=cuts,
+                         hwp=True, interpol=None)
+        result = make_map(obs, P=Proj, det_weights=2 * inv_var,
+                          det_weights_demod=inv_var)
+        wmap_dict[split_label] = result['weighted_map']
+        weights_dict[split_label] = result['weight']
+        # transform (3, 3, N, n) array to (3, N, n) keeping only diagonals
+        # in the first two dimensions
+        weights_dict[split_label] = np.moveaxis(
+            weights_dict[split_label].diagonal(), -1, 0
+        )
+
+    return wmap_dict, weights_dict
+
+
+@dataclass
+class Cfg:
+    """
+    Class to configure filtering
+
+    Args
+    --------
+    bundle_db: str
+        Path to bundling database
+    atomic_db: str
+        Path to atomic map database
+    preprocess_config_init: str
+        Path to preprocessing init yaml file
+    preprocess_config_proc: str
+        Path to preprocessing proc yaml file
+    query_restrict: str
+        SQL query to restrict obs from the atomic database
+    pix_type: str
+        'hp' or 'car'
+    sim_dir: str
+        Path to directory containing unfiltered input sims
+    atomic_sim_dir: str
+        Path to directory containing filtered atomic sims
+    output_dir: str
+        Path to output directory
+    sim_ids: list
+        Simulation seeds to be filtered, passed as integers
+    bundle_id: int
+        Bundle ID to be filtered
+    sim_string_format: str
+        String formatting for unfiltered input sims
+        must contain {sim_id} and {pure_type}.
+    freq_channel: str
+        Frequency channel, e.g. 'f090'.
+    intra_obs_splits: list
+        List of split labels for intra-obs splits, e.g. 'scan_left'.
+    intra_obs_pair: list
+        Pair of intra-obs labels that will be added to make full obs
+        for inter-obs splits
+    inter_obs_splits:
+        List of inter-obs split names for which to create bundles
+    car_map_template: str
+        Path to CAR map or geometry to be used as template
+    nside: int
+        HEALPix NSIDE parameter
+    fp_thin: int
+        Focal plane thinning factor applied to the sim filtering
+    nbatch_atomics: int
+        Number of batches to divide the bundle into, based on random timestamp
+        splits
+    """
+    pwg_scripts_dir: str
+    bb_awg_scripts_dir: str
+    bundle_db: str
+    atomic_db: str
+    preprocess_config_init: str
+    preprocess_config_proc: str
+    sim_dir: str
+    atomic_sim_dir: str
+    output_dir: str
+    sim_ids: list
+    sim_string_format: str
+    freq_channel: str
+    intra_obs_splits: list
+    query_restrict: Optional[str] = ""
+    pix_type: Optional[str] = "car"
+    bundle_id: Optional[int] = 0
+    intra_obs_pair: Optional[list] = None
+    inter_obs_splits: Optional[list] = None
+    car_map_template: Optional[str] = None
+    nside: Optional[int] = None
+    fp_thin: Optional[int] = 8
+    nbatch_atomics: Optional[int] = None
+
+    def __post_init__(self):
+        # Add extra defaults for private args not expected in config file
+        pass
+
+    @classmethod
+    def from_yaml(cls, path) -> "Cfg":
+        d = yaml_loader(path)
+        return cls(**d)

--- a/pipeline/misc/mpi_utils.py
+++ b/pipeline/misc/mpi_utils.py
@@ -47,6 +47,7 @@ def init(switch=False):
     except ImportError as exc:
         sys.stderr.write("IMPORT ERROR: " + __file__ + " (" + str(exc) + "). "
                          "Could not load mpi4py. MPI will not be used.\n")
+    return rank, size, comm
 
 
 def is_initialized():
@@ -132,8 +133,8 @@ def distribute_tasks(size, rank, ntasks, logger=None):
             local_task_ids.append(leftover[rank])
 
     if logger is not None:
-        logger.info(f"Rank {rank} has {len(local_task_ids)} tasks")
+        logger.info(f"Rank {rank} has {len(local_task_ids)} tasks.")
         logger.info(f"Total number of tasks is {ntasks}")
-    print("local_task_ids", np.array(local_task_ids, dtype=int))
+        logger.info(f"local_task_ids: {np.array(local_task_ids, dtype=int)}")
 
     return local_task_ids

--- a/users/kwolz/coadd_filtered_tf_sims.sh
+++ b/users/kwolz/coadd_filtered_tf_sims.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+bb_awg_scripts_dir=/home/kw6905/bbdev/bb-awg-scripts
+filtering_config=configs/filtering_config.yaml
+
+
+srun -n 32 -c 14 --cpu-bind=cores \
+python ${bb_awg_scripts_dir}/pipeline/filtering/coadd_filtered_sims.py \
+    --config_file $filtering_config

--- a/users/kwolz/configs/filtering_config.yaml
+++ b/users/kwolz/configs/filtering_config.yaml
@@ -7,7 +7,7 @@ atomic_db: /scratch/gpfs/SIMONSOBS/sat-iso/mapmaking/satp1_20250108/atomic_db.sq
 freq_channel: &freq_channel f150
 output_dir: &output_dir /scratch/gpfs/SIMONSOBS/sat-iso/transfer_function/satp1/f150
 sim_string_format: "{pure_type}_1.0arcmin_fwhm30.0_sim{sim_id:04d}_CAR.fits"
-sim_ids: [0, 1, 2, 3]
+sim_ids: [0]  # [0, 1, 2, 3]
 
 # (Optional for coadd_filtered_sims)
 intra_obs_splits: [scan_left, scan_right, det_left, det_right, det_in,
@@ -33,7 +33,7 @@ fp_thin: 8
 
 
 ## Required arguments for coadd_filtered_sims ##
-atomic_sim_dir: !path [*output_dir, *freq_channel, "{sim_id:04d}", *freq_channel]
+atomic_sim_dir: !path [*output_dir, "{sim_id:04d}", *freq_channel]
 # atomic_sim_dir: !path [*output_dir, atomic_sims, *freq_channel, "{sim_id:04d}"]
 
 

--- a/users/kwolz/configs/filtering_config.yaml
+++ b/users/kwolz/configs/filtering_config.yaml
@@ -1,0 +1,47 @@
+## Required shared arguments ##
+pwg_scripts_dir: &pwg_scripts_dir /home/kw6905/bbdev/pwg-scripts
+bb_awg_scripts_dir: &bb_awg_scripts_dir /home/kw6905/bbdev/bb-awg-scripts
+
+bundle_db: /scratch/gpfs/SIMONSOBS/sat-iso/mapmaking/satp1_20250108/bundles/bundles_south_seed17_20250304.db
+atomic_db: /scratch/gpfs/SIMONSOBS/sat-iso/mapmaking/satp1_20250108/atomic_db.sqlite
+freq_channel: &freq_channel f150
+output_dir: &output_dir /scratch/gpfs/SIMONSOBS/sat-iso/transfer_function/satp1/f150
+sim_string_format: "{pure_type}_1.0arcmin_fwhm30.0_sim{sim_id:04d}_CAR.fits"
+sim_ids: [0, 1, 2, 3]
+
+# (Optional for coadd_filtered_sims)
+intra_obs_splits: [scan_left, scan_right, det_left, det_right, det_in,
+                   det_out, det_lower, det_upper]
+
+
+## Optional shared arguments ##
+pix_type: car
+car_map_template: !path [*pwg_scripts_dir, iso-sat-review/mapmaking/band_car_fejer1_5arcmin.fits]
+bundle_id: 0
+query_restrict: "median_weight_qu < 2e10"
+
+
+## Required arguments for filter_sims_sotodlib ##
+preprocess_config_init: !path [*pwg_scripts_dir, iso-sat-review/transfer_function/transfer_preproc_config_20250108_sat_iso_init.yaml]
+preprocess_config_proc: !path [*pwg_scripts_dir, iso-sat-review/transfer_function/transfer_preproc_config_20250108_sat_iso_proc.yaml]
+sim_dir: /scratch/gpfs/SIMONSOBS/sat-iso/transfer_function/input_sims
+
+
+## Optional arguments for filter_sims_sotodlib ##
+# nside: 512
+fp_thin: 8
+
+
+## Required arguments for coadd_filtered_sims ##
+atomic_sim_dir: !path [*output_dir, *freq_channel, "{sim_id:04d}", *freq_channel]
+# atomic_sim_dir: !path [*output_dir, atomic_sims, *freq_channel, "{sim_id:04d}"]
+
+
+## Optional arguments for coadd_filtered_sims ##
+intra_obs_pair: [scan_left, scan_right]
+inter_obs_splits: [low_pwv, high_pwv, low_dpwv, high_dpwv, high_sun_distance,
+                   low_sun_distance, high_ambient_temperature,
+                   low_ambient_temperature, rising_azimuth, setting_azimuth,
+                   0_roll_angle, -45_roll_angle, +45_roll_angle,
+                   pos_f_hwp, neg_f_hwp]
+nbatch_atomics: 1

--- a/users/kwolz/filter_tf_sims.sh
+++ b/users/kwolz/filter_tf_sims.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+bb_awg_scripts_dir=/home/kw6905/bbdev/bb-awg-scripts
+filtering_config=configs/filtering_config.yaml
+
+
+srun -n 112 -c 4 --cpu_bind=cores \
+python ${bb_awg_scripts_dir}/pipeline/filtering/filter_sims_sotodlib.py \
+    --config_file $filtering_config


### PR DESCRIPTION
Major change:
- both "filtering sims" and "coadding filtered sims" now read from a common yaml file. [Example yaml](https://github.com/simonsobs/bb-awg-scripts/blob/filtering_config/users/kwolz/configs/filtering_config.yaml), [Example run script](https://github.com/simonsobs/bb-awg-scripts/blob/filtering_config/users/kwolz/filter_tf_sims.sh)

Minor changes:
- "filtering sims" now includes parallelization over simulations of different pure_types (pureT/E/B)
- get_ctimes is adapted to the new bundle_db as of March 2025