### PR TITLE
Bundler: Enable MPI

### DIFF
--- a/pipeline/bundling/bundle_maps.py
+++ b/pipeline/bundling/bundle_maps.py
@@ -19,7 +19,7 @@ def car2healpix(norm_hits_map):
     return reproject.map2healpix(norm_hits_map, spin=[0])
 
 
-def main(args):
+def main(args, parallelizor=None):
     """
     """
     args = args.copy()  # Make sure we don't accidentally modify the input args
@@ -92,7 +92,7 @@ def main(args):
             null_prop_val=split_inter_obs,
             map_dir=args.map_dir,
             abscal=args.abscal,
-            parallelizor=args.parallelizor
+            parallelizor=parallelizor
         )
 
         # Map naming convention
@@ -190,7 +190,6 @@ def main(args):
                 
 def _main(config_file, parallelizor):
     config = bundling_utils.Cfg.from_yaml(config_file)
-    config.parallelizor = parallelizor
     its = [np.atleast_1d(x) for x in [config.freq_channel, config.wafer]]
     patch_list = config.patch
 
@@ -225,7 +224,7 @@ def _main(config_file, parallelizor):
                         print(null_prop_val)
                         config2.null_prop_val_inter_obs = null_prop_val
                         try:
-                            main(config2)
+                            main(config2, parallelizor)
                         except ValueError as e:
                             print(e)
 
@@ -238,7 +237,7 @@ def _main(config_file, parallelizor):
                         print(split_val)
                         config2.split_label_intra_obs = split_val
                         try:
-                            main(config2)
+                            main(config2, parallelizor)
                         except ValueError as e:
                             print(e)
 
@@ -291,9 +290,9 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
     config = bundling_utils.Cfg.from_yaml(args.config_file)
-    nprocs = config.nprocs
-    rank, executor, as_completed_callable = get_exec_env(nprocs)
+    nproc = config.nproc
+    rank, executor, as_completed_callable = get_exec_env(nproc)
     if rank == 0:
-        _main(args.config_file, (executor, as_completed_callable, nprocs))
+        _main(args.config_file, (executor, as_completed_callable, nproc))
                         
 

--- a/pipeline/bundling/bundle_maps.py
+++ b/pipeline/bundling/bundle_maps.py
@@ -187,7 +187,7 @@ def main(args, parallelizor=None):
                 plt.savefig(out_fname.replace(".fits", f"{p}.png"))
                 plt.close()
 
-                
+
 def _main(config_file, parallelizor):
     config = bundling_utils.Cfg.from_yaml(config_file)
     its = [np.atleast_1d(x) for x in [config.freq_channel, config.wafer]]
@@ -294,5 +294,3 @@ if __name__ == "__main__":
     rank, executor, as_completed_callable = get_exec_env(nproc)
     if rank == 0:
         _main(args.config_file, (executor, as_completed_callable, nproc))
-                        
-

--- a/pipeline/bundling/bundle_maps.py
+++ b/pipeline/bundling/bundle_maps.py
@@ -287,10 +287,15 @@ if __name__ == "__main__":
     parser.add_argument(
         "--config_file", type=str, help="yaml file with configuration."
     )
+    parser.add_argument(
+        "--nproc", type=int, default=1, help="Number of parallel processes for concurrent futures."
+    )
 
     args = parser.parse_args()
-    config = bundling_utils.Cfg.from_yaml(args.config_file)
-    nproc = config.nproc
-    rank, executor, as_completed_callable = get_exec_env(nproc)
+    rank, executor, as_completed_callable = get_exec_env(args.nproc)
     if rank == 0:
+        try:
+            nproc = executor.num_workers
+        except AttributeError:
+            nproc = executor._max_workers
         _main(args.config_file, (executor, as_completed_callable, nproc))

--- a/pipeline/bundling/coadder.py
+++ b/pipeline/bundling/coadder.py
@@ -324,7 +324,7 @@ class Bundler(_Coadder):
         return ws, freq
 
     def bundle(self, bundle_id, split_label=None, null_prop_val=None,
-               map_dir=None, abscal=False, nproc=1):
+               map_dir=None, abscal=False, parallelizor=None):
         """
         Make a map bundle given a bundle ID and, optionally, null properties.
 
@@ -367,7 +367,7 @@ class Bundler(_Coadder):
 
         signal, weights, hits = coadd_maps(
             fnames, weights_list, hits_list, pix_type=self.pix_type,
-            car_template_map=self.car_map_template, abscal=abfac, nproc=nproc
+            car_template_map=self.car_map_template, abscal=abfac, parallelizor=parallelizor
             )
 
         return signal, weights, hits, fnames

--- a/pipeline/bundling/procs_pool.py
+++ b/pipeline/bundling/procs_pool.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+from typing import Tuple, Union, List, Callable, Optional
+
+
+def _get_mpi_comm() -> (
+    Tuple[bool, int, Optional["MPICommExecutor"], Optional[Callable]]
+):
+    """This private function tries to create an MPICommExecutor object and returns it if successful.
+
+    Returns
+    -------
+    bool
+        Whether an MPICommExecutor object was created successfully. This is important as only rank 0 creates the executor and all other ranks return None as an executor.
+    int
+        The global rank of the master process.
+    Optional["MPICommExecutor"]
+        If the executor was created successfully, this is the MPICommExecutor object. Otherwise, it is None.
+    Optional[Callable]
+        If the executor was created successfully, this is the as_completed function. Otherwise, it is None.
+    """
+    try:
+        from mpi4py.futures import MPICommExecutor
+        from mpi4py.futures import as_completed
+        from mpi4py import MPI
+
+        comm = MPI.COMM_WORLD
+
+        rank = comm.Get_rank()
+        max_workers = comm.Get_size() - 1
+
+        return (
+            True,
+            rank,
+            MPICommExecutor(comm, root=0, max_workers=max_workers).__enter__(),
+            as_completed,
+        )
+    except (NameError, ImportError, ValueError):
+        return False, 0, None, None
+
+
+def _get_concurrent_comm(
+    nprocs: Optional[int] = None,
+) -> Tuple[int, "ProcessPoolExecutor", Callable]:
+    """This private function tries to create an ProcessPoolExecutor object and returns it if successful.
+
+    Returns
+    -------
+    bool
+        Whether an ProcessPoolExecutor object was created successfully. This is important as only rank 0 creates the executor and all other ranks return None as an executor.
+    int
+        The global rank of the master process.
+    Optional["ProcessPoolExecutor"]
+        If the executor was created successfully, this is the ProcessPoolExecutor object. Otherwise, it is None.
+    Optional[Callable]
+        If the executor was created successfully, this is the as_completed function. Otherwise, it is None.
+    """
+
+    from concurrent.futures import ProcessPoolExecutor
+    from concurrent.futures import as_completed
+    from multiprocessing import set_start_method
+
+    set_start_method("spawn")
+    return True, 0, ProcessPoolExecutor(max_workers=nprocs), as_completed
+
+
+def get_exec_env(
+    nprocs: int = None, priority: List[str] = ["mpi", "process_pool"]
+) -> Tuple[int, Union["MPICommExecutor", "ProcessPoolExecutor"], Callable]:
+    """This function sets up the execution environment for parallel processing based on the specified priority list.
+
+    Since this function returns a rank value the main function needs to go under an
+    >>> if rank == 0
+
+    block to ensure that the code is only run by the master process.
+
+    In addition the main function needs to take the executor and as_completed_callable as arguments.
+
+    Let's assume that the main function is called main_func and it current state is as follows:
+    >>> def main_func():
+    >>>     with ProcessPoolExecutor() as executor:
+    >>>         futures = []
+    >>>         for i in range(10):
+    >>>             futures.append(executor.submit(some_func, i))
+    >>>         for future in as_completed(futures):
+    >>>             result = future.result()
+    >>>             print(result)
+    >>> if __name__ == "__main__":
+    >>>     main_func()
+
+
+    Utilizing different executors requires to change the main function as follows:
+    >>> def main_func(executor, as_completed_callable):
+    >>>     futures = []
+    >>>     for i in range(10):
+    >>>         futures.append(executor.submit(some_func, i))
+    >>>     for future in as_completed_callable(futures):
+    >>>         result = future.result()
+    >>>         print(result)
+    >>> if __name__ == "__main__":
+    >>>     rank, executor, as_completed_callable = get_exec_env(nprocs=4)
+    >>>     if rank == 0:
+    >>>         main_func(executor, as_completed_callable)
+
+
+    Parameters
+    ----------
+    nprocs : int, optional
+        The number of processes to use for the process pool executor. If not specified, the default is None.
+    priority : List[str], optional
+
+    Returns
+    -------
+    int
+        The rank of the process that is the master process for this type of execution
+
+    Union["MPICommExecutor", "ProcessPoolExecutor"]
+        The executor that is used to run the code in parallel. This can be either an MPICommExecutor or a ProcessPoolExecutor depending on the execution environment.
+
+    Callable
+        The as_completed function that is used to get the results of the parallel execution based on the type of the executor
+
+    Raises
+    ------
+    ValueError
+        When a valid executor is not available based on the execution priority list.
+    """
+    user_priority = list(priority)
+    executor_created = False
+    while not executor_created:
+        executor_mode = user_priority.pop(0)
+        if executor_mode == "mpi":
+            executor_created, rank, executor, as_completed_callable = (
+                _get_mpi_comm()
+            )
+        elif executor_mode == "process_pool":
+            executor_created, rank, executor, as_completed_callable = (
+                _get_concurrent_comm(nprocs)
+            )
+        else:
+            raise ValueError("No executor available")
+
+    return rank, executor, as_completed_callable


### PR DESCRIPTION
Enable MPI in the bundler using the procs_pool code from sotodlib.
Right now that is copied here to avoid adding a dependency on sotodlib.

This likely requires some modifications to scripts (ie filtering) that call the Coadder @kwolz @susannaaz 