### PR TITLE
more efficient signflip realizations

### DIFF
--- a/pipeline/bundling/coadder.py
+++ b/pipeline/bundling/coadder.py
@@ -312,6 +312,7 @@ class SignFlipper(_Coadder):
                                        is_weights=True)
                         for fname in self.fnames]
         print("weights: ", len(self.wmaps))
+        self._weights_noise = None
 
 
     def signflip(self, seed=None):
@@ -329,11 +330,23 @@ class SignFlipper(_Coadder):
         signflip_noise: np.array
             TQU map with th sign-flip noise realization.
         """
+        class _NoInplaceScale:
+            """Wrapper that prevents in-place scaling of cached maps in utils.sum_maps."""
+            def __init__(self, base):
+                self._base = base
+
+            def __getattr__(self, name):
+                return getattr(self._base, name)
+
+            def __imul__(self, other):
+                out = self._base.copy()
+                out *= other
+                return out
+
         if seed is not None:
             np.random.seed(seed)
         perm_idx = np.random.permutation(len(self.wmaps))
-        maps_list, weights_list = ([self.wmaps[i] for i in perm_idx],
-                                   [self.weights[i] for i in perm_idx])
+        maps_list = [_NoInplaceScale(self.wmaps[i]) for i in perm_idx]
 
         mean_wQU_list = [self.ws[i] for i in perm_idx]
         abscal = self.full_abscal[perm_idx]
@@ -342,10 +355,24 @@ class SignFlipper(_Coadder):
         pm_one = np.random.choice([-1, 1])
         sign_list = np.where(weight_cumsum < 0.5, pm_one, -pm_one)
 
-        signflip_noise, weights_noise = utils.coadd_maps(
-            maps_list, weights_list, pix_type=self.pix_type,
-            sign_list=sign_list, car_template_map=self.car_map_template,
-            abscal=abscal
+        if self._weights_noise is None:
+            weights_list = [self.weights[i] for i in perm_idx]
+            signflip_noise, weights_noise = utils.coadd_maps(
+                maps_list, weights_list, pix_type=self.pix_type,
+                sign_list=sign_list, car_template_map=self.car_map_template,
+                abscal=abscal
+            )
+            self._weights_noise = weights_noise
+            return signflip_noise, weights_noise
+
+        signflip_noise = utils.sum_maps(
+            maps_list,
+            self._weights_noise,
+            self.pix_type,
+            mult=sign_list * abscal**-1,
+            fields_hp=self.fields_hp
         )
 
-        return signflip_noise, weights_noise
+        good_weights = self._weights_noise > 0
+        signflip_noise[good_weights] /= self._weights_noise[good_weights]
+        return signflip_noise, self._weights_noise

--- a/pipeline/bundling/make_signflip_noise.py
+++ b/pipeline/bundling/make_signflip_noise.py
@@ -73,85 +73,94 @@ def _make_signflip(args, size, rank, comm, split_intra_obs=None, split_inter_obs
     task_ids = mpi.distribute_tasks(size, rank, n_missing,)
     #local_mpi_list = [mpi_shared_list[i] for i in task_ids]
 
-    # Loop over only missing tasks
-    #for task_id in mpi.taskrange(len(missing_tasks)):
-    #for task_id in mpi.taskrange(n_missing - 1):
+    # Group tasks by bundle_id so we can reuse SignFlipper. SignFlipper reads the
+    # per-bundle atomics into memory, and reusing it avoids repeating that work
+    # for every sim_id.
+    sim_ids_by_bundle = {}
     for task_id in task_ids:
         bundle_id, sim_id = missing_tasks[task_id]
-        print(f"Running bundle_id={bundle_id} sim_id={sim_id}")
+        sim_ids_by_bundle.setdefault(bundle_id, []).append(sim_id)
 
-        combined_map = None
-        combined_weight = None
-
-        # Now construct the signflipper (only for needed bundle_id)
+    # Loop over only missing tasks for this rank, grouped by bundle_id.
+    for bundle_id, sim_ids in sim_ids_by_bundle.items():
+        signflippers = []
         for bundle_db, map_dir_i in zip(sat_bundle_dbs, sat_map_dirs):
-            signflipper = SignFlipper(
-                bundle_db=bundle_db,
-                freq_channel=args.freq_channel,
-                wafer=args.wafer,
-                bundle_id=bundle_id,
-                null_prop_val=split_inter_obs,
-                pix_type=args.pix_type,
-                car_map_template=args.car_map_template,
-                split_label=split_intra_obs,
-                map_dir=map_dir_i,
-                atomic_list=args.atomic_list
-            )
+            signflippers.append((
+                bundle_db,
+                SignFlipper(
+                    bundle_db=bundle_db,
+                    freq_channel=args.freq_channel,
+                    wafer=args.wafer,
+                    bundle_id=bundle_id,
+                    null_prop_val=split_inter_obs,
+                    pix_type=args.pix_type,
+                    car_map_template=args.car_map_template,
+                    split_label=split_intra_obs,
+                    map_dir=map_dir_i,
+                    atomic_list=args.atomic_list,
+                    abscal=args.abscal
+                )
+            ))
 
-            print(len(signflipper.fnames))
+        for sim_id in sim_ids:
+            print(f"Running bundle_id={bundle_id} sim_id={sim_id}")
 
-            # NEW check here
-            if not signflipper.fnames:
-                print(f"Skipping bundle_id={bundle_id} sim_id={sim_id} (no atomic files)")
-                continue
+            combined_map = None
+            combined_weight = None
 
-            # Make noise map
-            try:
-                result = signflipper.signflip(seed=12345 * bundle_id + sim_id)
-                if not isinstance(result, (tuple, list)) or len(result) != 2:
-                    print(f"SignFlipper returned unexpected result for bundle_id={bundle_id} sim_id={sim_id} from {bundle_db}: {result}")
+            for bundle_db, signflipper in signflippers:
+                print(len(signflipper.fnames))
+                if not signflipper.fnames:
+                    print(f"Skipping bundle_id={bundle_id} sim_id={sim_id} (no atomic files)")
                     continue
-                noise_map, noise_weight = result
-            except Exception as e:
-                print(f"SignFlipper crashed for bundle_id={bundle_id} sim_id={sim_id} from {bundle_db}: {e}")
-                continue
 
-            # Initialize or accumulate
-            if combined_map is None:
-                combined_map = noise_map.copy()
-                combined_weight = noise_weight.copy()
-            else:
-                combined_map += noise_map
-                combined_weight += noise_weight
+                # Make noise map
+                try:
+                    result = signflipper.signflip(seed=12345 * bundle_id + sim_id)
+                    if not isinstance(result, (tuple, list)) or len(result) != 2:
+                        print(f"SignFlipper returned unexpected result for bundle_id={bundle_id} sim_id={sim_id} from {bundle_db}: {result}")
+                        continue
+                    noise_map, noise_weight = result
+                except Exception as e:
+                    print(f"SignFlipper crashed for bundle_id={bundle_id} sim_id={sim_id} from {bundle_db}: {e}")
+                    continue
+
+                # Initialize or accumulate
+                if combined_map is None:
+                    combined_map = noise_map.copy()
+                    combined_weight = noise_weight.copy()
+                else:
+                    combined_map += noise_map
+                    combined_weight += noise_weight
 
             if combined_map is None:
                 print(f"No valid maps for bundle_id={bundle_id} sim_id={sim_id}, skipping save.")
                 continue
 
-        # Output filenames
-        out_fname = os.path.join(
-            out_dir,
-            args.map_string_format.format(
-                split=split_tag,
-                bundle_id=bundle_id,
-                wafer=wafer_tag,
-                patch=patch_tag,
-                freq_channel=args.freq_channel,
-                map_type='{map_type}'
+            # Output filenames
+            out_fname = os.path.join(
+                out_dir,
+                args.map_string_format.format(
+                    split=split_tag,
+                    bundle_id=bundle_id,
+                    wafer=wafer_tag,
+                    patch=patch_tag,
+                    freq_channel=args.freq_channel,
+                    map_type='{map_type}'
+                )
             )
-        )
-        out_fname = out_fname.replace("__", "_")
-        out_fname = out_fname.replace("{map_type}", f"{sim_id:04d}"+"_{}")
+            out_fname = out_fname.replace("__", "_")
+            out_fname = out_fname.replace("{map_type}", f"{sim_id:04d}"+"_{}")
 
-        # Skip existing maps if overwrite=False
-        if (not args.overwrite) and os.path.exists(out_fname.format("map")):
-            if rank == 0:
-                print(f"Skipping existing: {out_fname}")
-            continue
+            # Skip existing maps if overwrite=False
+            if (not args.overwrite) and os.path.exists(out_fname.format("map")):
+                if rank == 0:
+                    print(f"Skipping existing: {out_fname}")
+                continue
 
-        # Save maps
-        print('writing maps: '+out_fname)
-        utils.write_maps(out_fname, args.pix_type, combined_map, combined_weight, dtype=np.float32)
+            # Save maps
+            print('writing maps: '+out_fname)
+            utils.write_maps(out_fname, args.pix_type, combined_map, combined_weight, dtype=np.float32)
 
         # Quickplots
         #if sim_id % (n_sims // 3) == 0:

--- a/pipeline/filtering/filter_sims_sotodlib.py
+++ b/pipeline/filtering/filter_sims_sotodlib.py
@@ -267,19 +267,19 @@ def main(args):
             meta.restrict("dets", thinned)
 
         # Process data here to have t2p leakage template
-        # Only need to run it once for all simulations
-        # and only the pre-demodulation part.
-        if args.t2p_template:
-            data_aman = pp_util.multilayer_load_and_preprocess(
-                obs_id,
-                configs_init,
-                configs_proc,
-                meta=meta,
-                logger=logger,
-                init_only=True,
-            )
-        else:
-            data_aman = None
+        # It will stop before each step with the
+        # use_data_aman flag in the preprocess config
+        # files and store the AxisManager in the data_aman
+        # dict.
+        data_aman = pp_util.multilayer_load_and_preprocess(
+            obs_id,
+            configs_init,
+            configs_proc,
+            meta=meta,
+            logger=logger,
+            stop_for_sims=True,
+            ignore_cfg_check=True
+        )
 
         for sim_id, sim_type in product(sim_ids, sim_types):
 
@@ -313,7 +313,8 @@ def main(args):
                     sim_map=sim,
                     meta=meta,
                     logger=logger,
-                    t2ptemplate_aman=data_aman
+                    ignore_cfg_check=True,
+                    data_amans=data_aman
                 )
             except loader.LoaderError:
                 logger.warning(


### PR DESCRIPTION
2 main changes

1. in `make_signflip_noise.py`: tasks were per (bundle_id, sim_id) and SignFlipper was constructed inside that loop. now a rank's task_ids are grouped by bundle_id first, and each SignFlipper is constructed once per bundle_id and per (bundle_db, map_dir), then looped over that bundle's sim_ids and then call signflip() 
2. in `coadder.SignFlipper`, the signflip denominator weights were computed for each sim which was useless, now on the first signflip call I store the positive weights_noise and reuse for different realizations

This reduces computing times of the signflip realizations significantly (over 6x times)